### PR TITLE
Get away from master/slave words

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,8 +28,8 @@ define("database_engine", default="mysql://root:123@127.0.0.1/jiushulou", help="
 define("txt_path", default="/home/work/txt", help="text file path")
 define("page_size", default=30, help="each page items num")
 # mysql server Options
-define("mysql_host_m", default='127.0.0.1', help="master hostname or IP address of the instance to connect to")
-define("mysql_host_s", default='127.0.0.1', help="slave hostname or IP address of the instance to connect to")
+define("mysql_host_m", default='127.0.0.1', help="main hostname or IP address of the instance to connect to")
+define("mysql_host_s", default='127.0.0.1', help="subordinate hostname or IP address of the instance to connect to")
 define("mysql_port", default=3306, help="port number on which to connect", type=int)
 define("mysql_db", default='jiushulou', help="database name")
 define("mysql_user", default='root', help="database name")


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.